### PR TITLE
Update CI runner from ubuntu-18.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
       - 'renovate/*'
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
ubuntu-18.04 runners were removed from GitHub Actions in April 2023. Updates to `ubuntu-latest` (currently 24.04).