### PR TITLE
Add Renovate config from renovate-config repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "github>TryGhost/renovate-config"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Renovate configuration for this repository
- use `github>TryGhost/renovate-config` as the shared preset source
- align this repository with the org standard Renovate setup