### PR TITLE
Update README example to use current GitHub Actions syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ on:
     - cron: "01 00 * * *"
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Update Ghost Posts
         uses: TryGhost/action-update-posts@v0
         with:
@@ -48,7 +48,7 @@ jobs:
           days: 30
 ```
 
-Using the schedule `"01 00 * * *"` will run this action once per day at one minute past midnight. For testing purposes, you may wish to use `""*/5 * * * *"`, which will run every 5 minutes.
+Using the schedule `"01 00 * * *"` will run this action once per day at one minute past midnight. For testing purposes, you may wish to use `"*/5 * * * *"`, which will run every 5 minutes.
 
 The example `with` configuration will find all posts tagged with `#early-access`, and if they were published more than 30 days ago, will update the `visibility` field to `public`.
 


### PR DESCRIPTION
## Summary

Fixed three issues in the example workflow snippet in the README that would break for anyone copy-pasting it today:

- `runs-on: ubuntu-18.04` → `ubuntu-latest`. The 18.04 runner image was retired by GitHub Actions; the repo's own `test.yml` was already migrated in #2, the README just hadn't caught up.
- `actions/checkout@master` → `actions/checkout@v4`. `@master` is the deprecated pattern, and `actions/checkout`'s default branch is `main` anyway.
- Cron string `""*/5 * * * *"` had a stray leading double quote, producing invalid YAML. Removed it.

No code changes — README only.

## Test plan

- [ ] Render README on GitHub and confirm the example block is syntactically clean
- [ ] Optional: drop the snippet into a workflow file in a scratch repo and confirm it parses and schedules