### PR TITLE
Updated repository docs for Action Update Posts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ Ghost Admin API. See `README.md` for user-facing setup and workflow examples.
   and semver tag.
 - `pnpm ship` runs `preship`, then pushes the current branch and tags when HEAD
   already has a `vX.Y.Z` tag.
+- `docs/release.md` documents the full two-step publishing flow and the
+  floating major-tag workflow.
 
 ## Boundaries
 

--- a/README.md
+++ b/README.md
@@ -1,92 +1,104 @@
 # Action Update Posts
 
-<p align="center">
-  <a href="https://ghost.org">
-    <img src="https://user-images.githubusercontent.com/65487235/157884383-1b75feb1-45d8-4430-b636-3f7e06577347.png" width="200px" alt="Ghost" />
-  </a>
-</p>
-<h3 align="center">Update Ghost Posts on a schedule</h3>
+Action Update Posts is a GitHub Action that updates Ghost posts on a schedule
+through the Ghost Admin API.
 
-<p align="center">
-    This <a href="https://github.com/features/actions">GitHub action</a> allows you to automatically update any fields of any <a href="https://ghost.org">Ghost</a> post <br>
-    on a schedule from GitHub via the Ghost Admin API!
-</p>
+Use it when a Ghost site needs scheduled post field changes, such as making
+posts public after an early-access period or unfeaturing posts after a campaign.
+The action finds posts by tag, checks how many days have passed since each post
+was published, and edits the chosen field when the configured threshold has
+passed.
 
----
+## Usage
 
-&nbsp;
+Create a Ghost custom integration in Ghost Admin, then add these repository
+secrets to the GitHub repository that will run the workflow:
 
+- `GHOST_ADMIN_API_URL`: the Admin API URL from the integration.
+- `GHOST_ADMIN_API_KEY`: the Admin API key from the integration.
 
-## Getting Started
-
-💡This action expects that you already have a working Ghost install running at least v3.20.0
-
-1. Generate a set of Ghost Admin API credentials, by configuring a new Custom Integration in Ghost Admin&raquo;Integrations.
-
-2. On GitHub, navigate to your theme repository&raquo;Settings&raquo;Secrets. Create a secret called `GHOST_ADMIN_API_URL` containing the API URL and another called `GHOST_ADMIN_API_KEY` containing the Admin API Key. Both must be copied exactly from Ghost Admin&raquo;Integrations.
-
-3. Once your secrets are in place, copy this example config into `.github/workflows/update-posts.yml`.
+Add a workflow such as `.github/workflows/update-posts.yml`:
 
 ```yml
 name: Update Ghost Posts
+
 on:
   schedule:
-    - cron: "01 00 * * *"
+    - cron: '1 0 * * *'
+
 jobs:
-  deploy:
+  update-posts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Update Ghost Posts
-        uses: TryGhost/action-update-posts@v0
+      - uses: TryGhost/action-update-posts@v0
         with:
           api-url: ${{ secrets.GHOST_ADMIN_API_URL }}
           api-key: ${{ secrets.GHOST_ADMIN_API_KEY }}
-          tag: 'hash-early-access'
-          field: 'visibility'
-          value: 'public'
+          tag: hash-early-access
+          field: visibility
+          value: public
           days: 30
 ```
 
-Using the schedule `"01 00 * * *"` will run this action once per day at one minute past midnight. For testing purposes, you may wish to use `"*/5 * * * *"`, which will run every 5 minutes.
+This example runs once per day at 00:01 UTC. It finds posts tagged
+`#early-access` and changes `visibility` to `public` once each post is more than
+30 days old.
 
-The example `with` configuration will find all posts tagged with `#early-access`, and if they were published more than 30 days ago, will update the `visibility` field to `public`.
+## Inputs
 
+| Key | Description | Required |
+| --- | --- | --- |
+| `api-url` | Ghost Admin API URL from the custom integration. | Yes |
+| `api-key` | Ghost Admin API key from the custom integration. | Yes |
+| `tag` | Tag slug to look up, for example `hash-early-access`. | Yes |
+| `field` | Post field to update, for example `visibility` or `featured`. | Yes |
+| `value` | New value for the field, for example `public` or `false`. String values of `true` and `false` are converted to booleans. | Yes |
+| `days` | Number of days after publish before the post should be updated. | Yes |
 
-4. Tweak the `tag`, `field`, `value` and `days` configuration values to whatever you like, and then commit and push your changes.
+## Examples
 
-
-## Configuration
-
-The `with` portion of the workflow **must** be configured before the action will work. Any `secrets` must be referenced using the bracket syntax and stored in the GitHub repositories `Settings/Secrets` menu. You can learn more about setting environment variables with GitHub actions [here](https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstepsenv).
-
-| Key  | Value Information | Type | Required |
-| ------------- | ------------- | ------------- | ------------- |
-| `api-url`  | The base URL of your Ghost Admin API, found by configuring a new Custom Integration in Ghost Admin&raquo;Integrations | `secrets` | **Yes** |
-| `api-key`  | The authentication key for your Ghost Admin API, found by configuring a new Custom Integration in Ghost Admin&raquo;Integrations | `secrets` | **Yes** |
-| `tag` | The tag to lookup to find posts to update e.g. `hash-early-access` | `string` | Yes |
-| `field` | The post field that you want to update e.g. `visibility` or `featured` | `string` | Yes |
-| `value` | The new value for the field e.g. `public` or `false` | `string` | Yes |
-| `days` | Number of days after the post was published to update the post e.g. 30 | `number` | Yes |
-
-### Examples
-
-
+Unfeature sponsored posts after seven days:
 
 ```yml
 with:
   api-url: ${{ secrets.GHOST_ADMIN_API_URL }}
   api-key: ${{ secrets.GHOST_ADMIN_API_KEY }}
-  tag: 'hash-sponsored'
-  field: 'featured'
+  tag: hash-sponsored
+  field: featured
   value: 'false'
   days: 7
 ```
 
-&nbsp;
+Publish members-only early access posts after 30 days:
 
-<p align="center">Don't forget to 🌟 Star 🌟 the repo if you like this GitHub Action !</p>
+```yml
+with:
+  api-url: ${{ secrets.GHOST_ADMIN_API_URL }}
+  api-key: ${{ secrets.GHOST_ADMIN_API_KEY }}
+  tag: hash-early-access
+  field: visibility
+  value: public
+  days: 30
+```
 
-# Copyright & License
+## Development
 
-Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE).
+This action runs on Node.js 24 in GitHub Actions and uses pnpm for local
+development.
+
+```sh
+pnpm install --frozen-lockfile
+pnpm lint
+pnpm test
+pnpm build
+```
+
+`pnpm build` refreshes `dist/index.js` from `index.js`. Commit the generated
+bundle whenever runtime code or dependencies change.
+
+See [docs/release.md](docs/release.md) for the publishing workflow.
+
+## Copyright & License
+
+Copyright (c) 2013-2026 Ghost Foundation - Released under the
+[MIT license](LICENSE).

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,45 @@
+# Release
+
+This repository publishes versioned GitHub Action tags. Consumers normally use
+the floating major tag, for example `TryGhost/action-update-posts@v0`.
+
+Publishing is intentionally split into two steps:
+
+1. Define the next version with `pnpm ship:version`.
+2. Ship the already-tagged release commit with `pnpm ship`.
+
+## Define the version
+
+Use `pnpm ship:version` with exactly one version argument:
+
+```sh
+pnpm ship:version patch
+pnpm ship:version minor
+pnpm ship:version major
+pnpm ship:version 0.1.0
+```
+
+The command delegates to `pnpm version`, creates the version commit, and creates
+the matching `vX.Y.Z` tag. Review the resulting commit and tag before shipping.
+
+## Ship the release
+
+After the version commit and tag exist on `HEAD`, run:
+
+```sh
+pnpm ship
+```
+
+The `ship` script runs the `preship` lifecycle first, so it verifies the build,
+lint, and test suite before pushing. It then checks that the working tree is
+clean and that `HEAD` has a full semver tag such as `v0.0.5`, then pushes the
+current branch and tags with `git push --follow-tags`.
+
+## Major tag
+
+The `.github/workflows/major.yml` workflow runs when a full semver tag is pushed.
+It updates the floating major tag that action consumers use, such as `v0` for
+`v0.0.5`.
+
+Do not push or move the floating major tag by hand during the normal release
+flow. Let the workflow update it from the full semver tag.


### PR DESCRIPTION
ref [GVA-808](https://linear.app/ghost/issue/GVA-808/clean-repos-action-update-posts)

## Summary
- Reworked `README.md` into a concise user-facing guide for what the action does, how to configure it, inputs, examples, and local development.
- Added `docs/release.md` for the maintainer publishing workflow: choose the version with `pnpm ship:version`, then ship the already-tagged commit with `pnpm ship`.
- Updated `AGENTS.md` to point future agents at the release doc instead of rediscovering the publishing flow.

## Docs ledger
- README: done, refreshed against `action.yml`, `index.js`, and `package.json` evidence.
- AGENTS: done, already concise and updated with the new release doc pointer.
- Supporting docs: done, added `docs/release.md` because the publishing flow and major-tag workflow are non-obvious operational details.
- Diagrams: not applicable, the action and release flow are linear enough that a Mermaid diagram would add noise.
- GitHub description: not applicable, live description already clearly says `GitHub action for making scheduled changes to posts (e.g. toggling featured)`.

## Verification
- `git diff --check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
