### PR TITLE
Use pro-ship for action-update-posts releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,9 @@ Ghost Admin API. See `README.md` for user-facing setup and workflow examples.
 - `pnpm test` runs Vitest with coverage; CI expects at least 80% statements,
   branches, functions, and lines.
 - `pnpm preship` is the local CI equivalent before publishing.
-- `pnpm ship:version <patch|minor|major|version>` creates the release commit
-  and semver tag.
-- `pnpm ship` runs `preship`, then pushes the current branch and tags when HEAD
-  already has a `vX.Y.Z` tag.
-- `docs/release.md` documents the full two-step publishing flow and the
+- `pnpm ship <patch|minor|major|version>` runs `preship`, then delegates to
+  `@tryghost/pro-ship` to create the release commit, semver tag, and push.
+- `docs/release.md` documents the publishing flow and the
   floating major-tag workflow.
 
 ## Boundaries

--- a/docs/release.md
+++ b/docs/release.md
@@ -3,37 +3,19 @@
 This repository publishes versioned GitHub Action tags. Consumers normally use
 the floating major tag, for example `TryGhost/action-update-posts@v0`.
 
-Publishing is intentionally split into two steps:
-
-1. Define the next version with `pnpm ship:version`.
-2. Ship the already-tagged release commit with `pnpm ship`.
-
-## Define the version
-
-Use `pnpm ship:version` with exactly one version argument:
+Publishing is handled by `@tryghost/pro-ship` through the repo's `ship` script:
 
 ```sh
-pnpm ship:version patch
-pnpm ship:version minor
-pnpm ship:version major
-pnpm ship:version 0.1.0
-```
-
-The command delegates to `pnpm version`, creates the version commit, and creates
-the matching `vX.Y.Z` tag. Review the resulting commit and tag before shipping.
-
-## Ship the release
-
-After the version commit and tag exist on `HEAD`, run:
-
-```sh
-pnpm ship
+pnpm ship patch
+pnpm ship minor
+pnpm ship major
+pnpm ship 0.1.0
 ```
 
 The `ship` script runs the `preship` lifecycle first, so it verifies the build,
-lint, and test suite before pushing. It then checks that the working tree is
-clean and that `HEAD` has a full semver tag such as `v0.0.5`, then pushes the
-current branch and tags with `git push --follow-tags`.
+lint, and test suite before releasing. `pro-ship` then runs `pnpm version`,
+creates the matching `vX.Y.Z` release commit and tag, and pushes with
+`git push --follow-tags`. The command only succeeds from a clean working tree.
 
 ## Major tag
 

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
     "format": "oxfmt .",
     "test": "vitest run --coverage",
     "preship": "pnpm build && pnpm lint && pnpm test",
-    "ship:version": "sh -c 'if [ \"$#\" -ne 1 ]; then echo \"Usage: pnpm ship:version <major|minor|patch|version>\"; exit 1; fi; pnpm version \"$1\" --message \"v%s\"' --",
-    "ship": "STATUS=$(git status --porcelain); echo \"$STATUS\"; if [ -n \"$STATUS\" ]; then echo \"Uncommitted changes present. Commit or stash changes before shipping.\"; exit 1; fi; TAG=$(git tag --points-at HEAD | grep -E \"^v[0-9]+\\.[0-9]+\\.[0-9]+$\" | head -n 1); if [ -z \"$TAG\" ]; then echo \"No vX.Y.Z tag points at HEAD. Run pnpm ship:version <major|minor|patch|version> first.\"; exit 1; fi; git push --follow-tags"
+    "ship": "pro-ship"
   },
   "files": [
     "index.js",
     "lib"
   ],
   "devDependencies": {
+    "@tryghost/pro-ship": "1.1.2",
     "@vercel/ncc": "0.44.0",
     "@vitest/coverage-v8": "4.1.9",
     "oxfmt": "0.56.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
         specifier: 1.14.10
         version: 1.14.10
     devDependencies:
+      '@tryghost/pro-ship':
+        specifier: 1.1.2
+        version: 1.1.2
       '@vercel/ncc':
         specifier: 0.44.0
         version: 0.44.0
@@ -442,6 +445,14 @@ packages:
   '@tryghost/admin-api@1.14.10':
     resolution: {integrity: sha512-B7Ov1Y/VhuNFsvDyN6DsNFcoqjpUccNrYFXsK5oy9sobZ/6AoRRW2kI4SHn4hrCcP89xPipVhTMcmhvoh0IhvQ==}
 
+  '@tryghost/pro-ship@1.1.2':
+    resolution: {integrity: sha512-o20xQ/kFbwvq9NylXN+/G3kxNAKNicFPOysAL+MspjStFftThGBj7miCgedWscZoQscDsb/6uKPFgRUyHti7Mw==}
+    engines: {node: '>=20.20.0'}
+    hasBin: true
+
+  '@tryghost/root-utils@2.3.1':
+    resolution: {integrity: sha512-1g0HskTTDJzn3CzcEWhd4aKtcmPm3IztD7cyfQQiG4QX+6gfpPOkYk7Y5gDOwTKAYtfor0nc8npSY90vvIj93A==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -520,6 +531,9 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  caller@1.1.0:
+    resolution: {integrity: sha512-n+21IZC3j06YpCWaxmUy5AnVqhmCIM2bQtqQyy00HJlmStRt6kwDX5F9Z97pqwAB+G/tgSz6q/kUBbNyQzIubw==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -589,6 +603,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -1236,6 +1253,16 @@ snapshots:
       - debug
       - supports-color
 
+  '@tryghost/pro-ship@1.1.2':
+    dependencies:
+      '@tryghost/root-utils': 2.3.1
+      semver: 7.8.5
+
+  '@tryghost/root-utils@2.3.1':
+    dependencies:
+      caller: 1.1.0
+      find-root: 1.1.0
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -1340,6 +1367,8 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  caller@1.1.0: {}
+
   chai@6.2.2: {}
 
   combined-stream@1.0.8:
@@ -1392,6 +1421,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  find-root@1.1.0: {}
 
   follow-redirects@1.16.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+minimumReleaseAgeExclude:
+  - '@tryghost/pro-ship@1.1.2'
+  - '@tryghost/root-utils@2.3.1'


### PR DESCRIPTION
## Summary
- add @tryghost/pro-ship and use it for `pnpm ship`
- replace the custom `ship:version` plus tag-push flow with the shared pnpm-aware release command
- update agent and release docs for `pnpm ship <patch|minor|major|version>`

## Validation
- `pnpm install --frozen-lockfile && pnpm preship`