### PR TITLE
Standardized the required CI check on the org-wide aggregator gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [lint, tests]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Branch protection on this repo currently requires a status check named exactly `All tests pass`. Requiring individual or legacy check names couples branch protection to the CI matrix and job naming: rename the job and the required check silently stops existing, blocking every PR.

The org is standardizing every repository on one stable aggregator check named `Required checks pass` (the `repo-ci-required-check` convention). This PR renames the existing gate job to that convention — job id `required-checks-pass`, name `Required checks pass` — with identical coverage (`needs: [lint, tests]`, which is every job in the workflow) and the same failure semantics.

The branch ruleset is being updated in the same pass to require `Required checks pass`, so this PR must go green on the new gate before it can merge.