### PR TITLE
Docs: clarify test setup and Node versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,9 @@ Ghost Admin API. See `README.md` for user-facing setup and workflow examples.
 - CI fails pull requests whose committed `dist/index.js` is stale. Renovate
   PRs are exempt; `.github/workflows/sync-dist.yml` rebuilds `dist/` on `main`
   after they merge (requires the `SYNC_DIST_GH_TOKEN` repository secret).
-- Do not commit real Ghost Admin API URLs or keys. Tests should use mocked
-  `core` and Admin API modules, as in `index.test.mjs`.
+- Do not commit real Ghost Admin API URLs or keys. `index.test.mjs` holds unit
+  tests with mocked `core` and Admin API modules; `action.test.mjs` is an
+  acceptance test that runs the bundled `dist/index.js` against a local mock
+  Admin API server. Follow those patterns rather than using real credentials.
 - Keep `CLAUDE.md` as the symlink to this file rather than duplicating agent
   instructions.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ with:
 
 ## Development
 
-This action runs on Node.js 24 in GitHub Actions and uses pnpm for local
-development.
+In GitHub Actions the action runs on the Node.js 24 runtime (set by
+`runs.using: node24` in `action.yml`). Local development supports Node.js
+22.13.0 or newer (see `engines` in `package.json`), and CI runs the tests on
+both Node.js 22 and 24. It uses pnpm for local development.
 
 ```sh
 pnpm install --frozen-lockfile


### PR DESCRIPTION
This came out of a repo docs audit. Two small documentation fixes, no runtime changes.

## Changes

- **AGENTS.md**: The mocking guidance referenced only `index.test.mjs`. It now describes both test files: `index.test.mjs` (unit tests with mocked `core`/Admin API) and `action.test.mjs` (acceptance test that runs the bundled `dist/index.js` against a local mock Admin API server), so the intended test patterns are discoverable.
- **README.md**: The Development section said the action "runs on Node.js 24" without distinguishing the Actions runtime from local development. It now separates the action runtime (Node 24, per `action.yml` `runs.using: node24`) from local development support (Node >=22.13.0 per `package.json` engines; CI tests Node 22 and 24).

`pnpm lint` passes locally.

> Note: The required status check "Required checks pass" will only report after the CI-trust PR merges and this branch is updated.